### PR TITLE
fix: Run `php artisan optimize` command on start up

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,4 +14,4 @@ RUN composer install
 
 EXPOSE 8080
 
-CMD php artisan serve --host=0.0.0.0 --port=8080
+CMD ./start.sh

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: bash start.sh

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+php artisan optimize
+php artisan serve --host=0.0.0.0 --port=8080


### PR DESCRIPTION
Updates sample to use Procfile to run `php artisan optimize` on start up

Related to documentation issue https://github.com/Scalingo/documentation/issues/2843