### PR TITLE
fix: Use PORT environment variable for server

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
     ports:
       - 3000:8080
     environment:
+      PORT: 8080
       DB_CONNECTION: mysql
       DB_HOST: db
       DB_PORT: 3306

--- a/start.sh
+++ b/start.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 php artisan optimize
-php artisan serve --host=0.0.0.0 --port=8080
+php artisan serve --host=0.0.0.0 --port=$PORT


### PR DESCRIPTION
The sample did not boot on Scalingo because it was not using the $PORT environment variable.
